### PR TITLE
Switch to non-blocking calls to Meilisearch

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ fastapi[all]~=0.92.0
 psycopg2-binary
 bcrypt~=4.0.1
 pydantic~=1.10.5
-meilisearch~=0.25.0
+meilisearch-python-async~=1.0.0
 uvicorn~=0.20.0
 Pillow~=9.4.0

--- a/src/app/functions/meilisearch/MSIndex.py
+++ b/src/app/functions/meilisearch/MSIndex.py
@@ -1,4 +1,4 @@
-import meilisearch
+import meilisearch_python_async
 
 from ..dbconfig import meilisearchConfig
 
@@ -7,42 +7,40 @@ async def IndexPost(postid: int, authorid: int, authorusername: str, title: str,
                     media: str, timestamp: int, topic: str, edited: bool):
     msdb = meilisearchConfig()[0]
     msdbkey = meilisearchConfig()[1]
-    client = meilisearch.Client(msdb, msdbkey)
-
-    client.index('posts').update_documents([{
-        'id': int(postid),
-        'authorid': str(authorid),
-        'author': authorusername,
-        'title': title,
-        'content': textcontent,
-        'media': media,
-        'timestamp': str(timestamp),
-        'topic': topic,
-        'edited': edited
-    }],
-        'id'  # primary key for MS posts.
-        # this is so MS can understand how many posts there are and how to identify one from another.
-    )
+    async with meilisearch_python_async.Client(msdb, msdbkey) as client:
+        await client.index('posts').update_documents([{
+            'id': int(postid),
+            'authorid': str(authorid),
+            'author': authorusername,
+            'title': title,
+            'content': textcontent,
+            'media': media,
+            'timestamp': str(timestamp),
+            'topic': topic,
+            'edited': edited
+        }],
+            'id'  # primary key for MS posts.
+            # this is so MS can understand how many posts there are and how to identify one from another.
+        )
 
 
 async def IndexUser(userid, username, alias, email, unixtimejoined, bio, modnotes, trusted, mod, badges, official):
     msdb = meilisearchConfig()[0]
     msdbkey = meilisearchConfig()[1]
-    client = meilisearch.Client(msdb, msdbkey)
-
-    client.index('users').update_documents([{
-        'id': int(userid),  # a meilisearch user id is
-        'username': str(username),
-        'alias': str(alias),
-        'email': str(email),
-        'unixtime_joined': unixtimejoined,
-        'bio': bio,
-        'modnotes': modnotes,
-        'is_trusted': trusted,
-        'is_moderator': mod,
-        'badges': badges,
-        'is_official': official
-    }],
-        'id'  # primary key for MS users.
-        # this is so MS can understand how many users there are and how to identify one from another.
-    )
+    async with meilisearch_python_async.Client(msdb, msdbkey) as client:
+        await client.index('users').update_documents([{
+            'id': int(userid),  # a meilisearch user id is
+            'username': str(username),
+            'alias': str(alias),
+            'email': str(email),
+            'unixtime_joined': unixtimejoined,
+            'bio': bio,
+            'modnotes': modnotes,
+            'is_trusted': trusted,
+            'is_moderator': mod,
+            'badges': badges,
+            'is_official': official
+        }],
+            'id'  # primary key for MS users.
+            # this is so MS can understand how many users there are and how to identify one from another.
+        )

--- a/src/app/functions/meilisearch/MSSearch.py
+++ b/src/app/functions/meilisearch/MSSearch.py
@@ -1,4 +1,4 @@
-import meilisearch
+import meilisearch_python_async
 from ..dbconfig import meilisearchConfig
 from fastapi import HTTPException
 import traceback
@@ -11,14 +11,11 @@ async def MSSearchPosts(searchterm: str, page: int):
     try:
         msdb = meilisearchConfig()[0]
         msdbkey = meilisearchConfig()[1]
-        client = meilisearch.Client(msdb, msdbkey)
-
-        index = client.index('posts')  # set index to posts
-        result = index.search(searchterm, {
-            'offset': page
-        })  # search for {searchterm} on page {page}
+        async with meilisearch_python_async.Client(msdb, msdbkey) as client:
+            index = client.index('posts')  # set index to posts
+            result = await index.search(searchterm, offset=page)  # search for {searchterm} on page {page}
         return result  # return search results
-    except (Exception, meilisearch.client.MeiliSearchError):
+    except (Exception, meilisearch_python_async.errors.MeilisearchError):
         await logErrorToDB(str(traceback.format_exc()))
         raise HTTPException(
             status_code=500,
@@ -36,14 +33,11 @@ async def MSSearchUsers(searchterm: str, page: int):
     try:
         msdb = meilisearchConfig()[0]
         msdbkey = meilisearchConfig()[1]
-        client = meilisearch.Client(msdb, msdbkey)
-
-        index = client.index('users')  # set index to users
-        result = index.search(searchterm, {
-            'offset': page
-        })  # search for {searchterm} on page {page}
+        async with meilisearch_python_async.Client(msdb, msdbkey) as client:
+            index = client.index('users')  # set index to users
+            result = await index.search(searchterm, offset=page)  # search for {searchterm} on page {page}
         return result  # return search results
-    except (Exception, meilisearch.client.MeiliSearchError):
+    except (Exception, meilisearch_python_async.errors.MeilisearchError):
         await logErrorToDB(str(traceback.format_exc()))
         raise HTTPException(
             status_code=500,


### PR DESCRIPTION
With your current implementation using the `meilisearch-python` client the calls to Meilisearch are blocking your event loop because this package is not async capable. This PR switches to the `meilisearch-python-async` client in order to make the Meilisearch calls non-blocking.